### PR TITLE
Fix validators endpoint 

### DIFF
--- a/validators.go
+++ b/validators.go
@@ -152,16 +152,15 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				return
 			}
 
-			if validatorsResponse != nil || validatorsResponse.GetPagination().GetNextKey() != nil {
-				break
-			}
-
 			validators := validatorsResponse.GetValidators()
 			sublogger.Info().Int("NumValidators", len(validators)).Msg("Validators on this page")
 			allValidators = append(allValidators, validators...)
+			if validatorsResponse != nil || validatorsResponse.GetPagination().GetNextKey() != nil {
+				break
+			}
 		}
 
-		sublogger.Info().Int("NumValidators", len(validators)).Msg("Validators in total")
+		sublogger.Info().Int("TotalValidators", len(validators)).Msg("Validators in total")
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")

--- a/validators.go
+++ b/validators.go
@@ -164,14 +164,14 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			offset = uint64(len(allValidators))
 		}
 
-		sublogger.Info().Int("TotalValidators", len(validators)).Msg("Validators in total")
+		sublogger.Info().Int("TotalValidators", len(allValidators)).Msg("Validators in total")
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")
 
 		// sorting by delegator shares to display rankings
 		sort.Slice(allValidators, func(i, j int) bool {
-			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)
+			return allValidators[i].DelegatorShares.GT(allValidators[j].DelegatorShares)
 		})
 	}()
 

--- a/validators.go
+++ b/validators.go
@@ -162,7 +162,6 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			offset = uint64(len(validators))
 		}
 
-		sublogger.Info().Int("TotalValidators", len(validators)).Msg("Validators in total")
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")
@@ -363,12 +362,10 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			active := float64(1)
 
 			if validator.Jailed {
-				sublogger.Info().Str("moniker", validator.Description.Moniker).Int("activeValidators", activeValidators).Msg("Validator is jailed, not returning active status")
 				active = 0
 			}
 
 			if activeValidators == int(validatorSetLength) {
-				sublogger.Info().Str("moniker", validator.Description.Moniker).Int("Index", index).Int("activeValidators", activeValidators).Msg("Already at max active set, not returning active status")
 				active = 0
 			}
 
@@ -379,8 +376,6 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				"moniker":     validator.Description.Moniker,
 				"pubkey_hash": strings.ToUpper(hex.EncodeToString(pubKey.Bytes())),
 			}).Set(active)
-
-			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Int("activeValidators", activeValidators).Msg("Validator status")
 		}
 	}
 	sublogger.Info().Int("activeValidators", activeValidators).Msg("Active validators")

--- a/validators.go
+++ b/validators.go
@@ -372,6 +372,8 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				active = 0
 			}
 
+			activeValidators += int(active)
+
 			validatorsIsActiveGauge.With(prometheus.Labels{
 				"address":     validator.OperatorAddress,
 				"moniker":     validator.Description.Moniker,
@@ -380,6 +382,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Msg("Validator is active ")
 		}
 	}
+	sublogger.Info().Int("activeValidators", activeValidators).Msg("Active validators")
 
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)

--- a/validators.go
+++ b/validators.go
@@ -158,7 +158,6 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				break
 			}
 
-			sublogger.Info().Int("NumValidators", len(validatorsOnPage)).Msg("Validators on this page")
 			validators = append(validators, validatorsOnPage...)
 			offset = uint64(len(validators))
 		}

--- a/validators.go
+++ b/validators.go
@@ -227,7 +227,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 
 	wg.Wait()
 
-	sublogger.Debug().
+	sublogger.Info().
 		Int("signingLength", len(signingInfos)).
 		Int("validatorsLength", len(validators)).
 		Msg("Validators info")

--- a/validators.go
+++ b/validators.go
@@ -155,10 +155,13 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			if validatorsResponse != nil || validatorsResponse.GetPagination().GetNextKey() != nil {
 				break
 			}
-			allValidators = append(allValidators, validatorsResponse.GetValidators()...)
 
+			validators := validatorsResponse.GetValidators()
+			sublogger.Info().Int("NumValidators", len(validators)).Msg("Validators on this page")
+			allValidators = append(allValidators, validators...)
 		}
 
+		sublogger.Info().Int("NumValidators", len(validators)).Msg("Validators in total")
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")

--- a/validators.go
+++ b/validators.go
@@ -136,7 +136,6 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 
 		stakingClient := stakingtypes.NewQueryClient(grpcConn)
 
-		allValidators := []stakingtypes.Validator{}
 		offset := uint64(0)
 		for {
 			validatorsResponse, err := stakingClient.Validators(
@@ -154,24 +153,24 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				return
 			}
 
-			validators := validatorsResponse.GetValidators()
-			if validatorsResponse == nil || len(validators) == 0 {
+			validatorsOnPage := validatorsResponse.GetValidators()
+			if validatorsResponse == nil || len(validatorsOnPage) == 0 {
 				break
 			}
 
-			sublogger.Info().Int("NumValidators", len(validators)).Msg("Validators on this page")
-			allValidators = append(allValidators, validators...)
-			offset = uint64(len(allValidators))
+			sublogger.Info().Int("NumValidators", len(validatorsOnPage)).Msg("Validators on this page")
+			validators = append(validators, validatorsOnPage...)
+			offset = uint64(len(validators))
 		}
 
-		sublogger.Info().Int("TotalValidators", len(allValidators)).Msg("Validators in total")
+		sublogger.Info().Int("TotalValidators", len(validators)).Msg("Validators in total")
 		sublogger.Debug().
 			Float64("request-time", time.Since(queryStart).Seconds()).
 			Msg("Finished querying validators")
 
 		// sorting by delegator shares to display rankings
-		sort.Slice(allValidators, func(i, j int) bool {
-			return allValidators[i].DelegatorShares.GT(allValidators[j].DelegatorShares)
+		sort.Slice(validators, func(i, j int) bool {
+			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)
 		})
 	}()
 

--- a/validators.go
+++ b/validators.go
@@ -155,7 +155,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			}
 
 			validators := validatorsResponse.GetValidators()
-			if validatorsResponse != nil || len(validators) == 0 {
+			if validatorsResponse == nil || len(validators) == 0 {
 				break
 			}
 

--- a/validators.go
+++ b/validators.go
@@ -363,12 +363,12 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 			active := float64(1)
 
 			if validator.Jailed {
-				sublogger.Info().Str("moniker", validator.Description.Moniker).Msg("Validator is jailed, not returning active status")
+				sublogger.Info().Str("moniker", validator.Description.Moniker).Int("activeValidators", activeValidators).Msg("Validator is jailed, not returning active status")
 				active = 0
 			}
 
-			if activeValidators+1 > int(validatorSetLength) {
-				sublogger.Info().Str("moniker", validator.Description.Moniker).Int("Index", index).Msg("Already at max active set, not returning active status")
+			if activeValidators == int(validatorSetLength) {
+				sublogger.Info().Str("moniker", validator.Description.Moniker).Int("Index", index).Int("activeValidators", activeValidators).Msg("Already at max active set, not returning active status")
 				active = 0
 			}
 
@@ -379,7 +379,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				"moniker":     validator.Description.Moniker,
 				"pubkey_hash": strings.ToUpper(hex.EncodeToString(pubKey.Bytes())),
 			}).Set(active)
-			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Msg("Validator is active ")
+			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Int("activeValidators", activeValidators).Msg("Validator is active ")
 		}
 	}
 	sublogger.Info().Int("activeValidators", activeValidators).Msg("Active validators")

--- a/validators.go
+++ b/validators.go
@@ -169,7 +169,7 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 
 		// sorting by delegator shares to display rankings
 		sort.Slice(validators, func(i, j int) bool {
-			return validators[i].DelegatorShares.GT(validators[j].DelegatorShares)
+			return validators[i].Tokens.GT(validators[j].Tokens)
 		})
 	}()
 
@@ -379,7 +379,8 @@ func ValidatorsHandler(w http.ResponseWriter, r *http.Request, grpcConn *grpc.Cl
 				"moniker":     validator.Description.Moniker,
 				"pubkey_hash": strings.ToUpper(hex.EncodeToString(pubKey.Bytes())),
 			}).Set(active)
-			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Int("activeValidators", activeValidators).Msg("Validator is active ")
+
+			sublogger.Info().Str("moniker", validator.Description.Moniker).Int("isActive", int(active)).Int("activeValidators", activeValidators).Msg("Validator status")
 		}
 	}
 	sublogger.Info().Int("activeValidators", activeValidators).Msg("Active validators")


### PR DESCRIPTION
- is active check was wrong 
    - it's sorted by delegatorShares to determine the active set, which is incorrect as the SDK sorts it based on total voting power. i.e tokens staked with a validator. This is why ContributionDAO was not active according to cosmos-exporter 
    - The delegator shares is not a 1-1 mapping for voting power, its based on how many shared issued in the staking module 

- Not handling pagination might be an issue if our inactive validator set grows 

http://18.195.69.116:9300/metrics/validators
![image](https://github.com/sei-protocol/sei-cosmos-exporter/assets/18161326/64446a9e-b6f8-4af0-94bd-f757a9fdde9d)
