### PR TITLE
fix: wait for tendermint rpc before starting cosmos-exporter and auto retry

### DIFF
--- a/install-sei-cosmos-exporter.sh
+++ b/install-sei-cosmos-exporter.sh
@@ -25,9 +25,10 @@ Group=cosmos_exporter
 TimeoutStartSec=0
 CPUWeight=95
 IOWeight=95
+ExecStartPre=/bin/bash -c 'timeout 300 bash -c "until curl -sf http://localhost:26657/status > /dev/null 2>&1; do sleep 5; done"'
 ExecStart=/usr/bin/sei-cosmos-exporter --denom $BOND_DENOM --denom-coefficient 1000000 --bech-prefix $BENCH_PREFIX
 Restart=always
-RestartSec=2
+RestartSec=10
 LimitNOFILE=800000
 KillSignal=SIGTERM
 
@@ -38,5 +39,8 @@ EOF
 sudo systemctl daemon-reload
 sudo systemctl enable cosmos-exporter
 sudo systemctl restart cosmos-exporter
+
+# Health check cron: restart cosmos-exporter if /metrics/general is unreachable
+(sudo crontab -l 2>/dev/null | grep -v 'metrics/general.*cosmos-exporter'; echo '*/5 * * * * curl -sf --max-time 5 http://localhost:9300/metrics/general > /dev/null || { logger -t cosmos-exporter-healthcheck "metrics unreachable, restarting"; systemctl restart cosmos-exporter; }') | sudo crontab -
 
 echo "installed"


### PR DESCRIPTION
Wait for Tendermint RPC before starting cosmos-exporter, increase restart interval to 10s, and add a cron health check that auto-restarts if `/metrics/general` becomes unreachable.