### PR TITLE
feat: containerize + publish to sei ECR

### DIFF
--- a/.github/workflows/ecr.yaml
+++ b/.github/workflows/ecr.yaml
@@ -1,0 +1,40 @@
+name: ECR
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag (defaults to git sha)"
+        required: false
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::189176372795:role/common/gha
+          role-duration-seconds: 900
+          aws-region: us-east-2
+
+      - id: ecr-login
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64
+          tags: ${{ steps.ecr-login.outputs.registry }}/sei/sei-cosmos-exporter:${{ inputs.tag || github.sha }}
+          cache-from: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared
+          cache-to: type=registry,ref=${{ steps.ecr-login.outputs.registry }}/sei/build-cache:shared,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1.7
+
+# ----- builder ------------------------------------------------------------
+# Pinned to 1.20 because cosmos-sdk v0.45.4 (this repo's transitive dep) does
+# not compile cleanly under 1.21+ stdlib changes. Bump in lock-step with any
+# cosmos-sdk upgrade.
+FROM golang:1.20-alpine AS builder
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
+
+COPY . .
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
+    go build -trimpath -ldflags="-s -w" -buildvcs=false \
+    -o /out/sei-cosmos-exporter ./
+
+# ----- runtime ------------------------------------------------------------
+# distroless nonroot pins UID/GID 65532 — matches the controller's
+# sidecarSecurityContext (RunAsNonRoot + RunAsUser 65532) so the
+# pod's fsGroup propagation works without extra config.
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /out/sei-cosmos-exporter /usr/local/bin/sei-cosmos-exporter
+
+EXPOSE 9300
+
+USER nonroot:nonroot
+
+ENTRYPOINT ["/usr/local/bin/sei-cosmos-exporter"]
+
+# Sei-flavored defaults. K8s pod spec passes explicit Args which overrides
+# this — see sei-k8s-controller buildCosmosExporterContainer.
+CMD ["--denom", "usei", \
+     "--denom-coefficient", "1000000", \
+     "--bech-prefix", "sei", \
+     "--listen-address", ":9300"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Pinned to 1.20 because cosmos-sdk v0.45.4 (this repo's transitive dep) does
 # not compile cleanly under 1.21+ stdlib changes. Bump in lock-step with any
 # cosmos-sdk upgrade.
-FROM golang:1.20-alpine AS builder
+FROM golang:1.20-alpine@sha256:e47f121850f4e276b2b210c56df3fda9191278dd84a3a442bfe0b09934462a8f AS builder
 
 RUN apk add --no-cache git ca-certificates
 
@@ -26,7 +26,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 # distroless nonroot pins UID/GID 65532 — matches the controller's
 # sidecarSecurityContext (RunAsNonRoot + RunAsUser 65532) so the
 # pod's fsGroup propagation works without extra config.
-FROM gcr.io/distroless/static-debian12:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot@sha256:a9329520abc449e3b14d5bc3a6ffae065bdde0f02667fa10880c49b35c109fd1
 
 COPY --from=builder /out/sei-cosmos-exporter /usr/local/bin/sei-cosmos-exporter
 


### PR DESCRIPTION
## Why

Legacy sei-infra built this binary from source on every EC2 host (`install-sei-cosmos-exporter.sh` + systemd). The K8s migration runs it as a sidecar in seid pods (rendered by `sei-k8s-controller`, see [sei-k8s-controller#249](https://github.com/sei-protocol/sei-k8s-controller/pull/249)), which needs a published OCI image at a known registry.

No image existed; nothing in this repo built one. This PR fixes that.

## What

### Dockerfile (multi-stage)

- `golang:1.20-alpine` builder → `gcr.io/distroless/static-debian12:nonroot` runtime
- UID/GID `65532` matches `sei-k8s-controller/internal/noderesource.sidecarSecurityContext.RunAsUser` so pod `fsGroup` propagation works without extra config
- `CGO_ENABLED=0` static binary; `-trimpath -ldflags=\"-s -w\" -buildvcs=false`
- Final image: **56MB** (verified locally)
- `CMD` carries Sei-flavored defaults (`--denom usei --denom-coefficient 1000000 --bech-prefix sei --listen-address :9300`) so a bare `docker run` Just Works; K8s pod spec passes explicit `Args` which overrides `CMD`

### `.github/workflows/ecr.yaml`

Mirrors `sei-k8s-controller/.github/workflows/ecr.yml` exactly:
- Triggers on `push: branches: [main]` and `workflow_dispatch` (with optional `tag` input)
- Same IAM role via OIDC: `arn:aws:iam::189176372795:role/common/gha`
- Same shared build cache: `<registry>/sei/build-cache:shared`
- `linux/amd64` only
- Image path: `<registry>/sei/sei-cosmos-exporter:<github.sha>`

### Compatibility

- Go pinned to `1.20` because cosmos-sdk v0.45.4 (this repo's transitive dep) doesn't compile cleanly on 1.21+ stdlib changes. Bump in lock-step with any cosmos-sdk upgrade.
- Existing `actions.yaml` (go build + go vet) and `release.yaml` (GoReleaser binary releases on tags) are untouched — parallel artifact paths.

## Test plan

- [x] `docker build -t sei-cosmos-exporter:test .` succeeds locally
- [x] `docker run --rm sei-cosmos-exporter:test --help` prints flag help (binary loads, no immediate Fatal)
- [x] Image size verified at 56.3MB (`docker images`)
- [x] CI publishes on merge to main; digest goes into `sei-k8s-controller`'s `SEI_COSMOS_EXPORTER_IMAGE` env via a follow-up bump